### PR TITLE
File utility tests

### DIFF
--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -76,16 +76,20 @@ bool FileUtility::generalized_getline(std::string& retval) {
 int FileUtility::read_file(void* buffer, size_t chars_to_read) {
   size_t buf_position = 0;
   if(str_buffer.size() > 0) {
-    size_t readable_chars = std::min<size_t>(str_buffer.size(), chars_to_read);
-    memcpy(buffer, str_buffer.c_str(), readable_chars);
-    str_buffer.erase(0, readable_chars);
-    chars_to_read = std::min<size_t>(0, chars_to_read - readable_chars);
-    buf_position += readable_chars;
+    buf_position = read_from_str_buffer(buffer, chars_to_read);
+    chars_to_read -= buf_position;
   }
-  int rcode = TileDBUtils::read_file(filename, chars_read + buf_position, buffer, chars_to_read);
-  chars_read += (chars_to_read + buf_position);
+  int rcode = TileDBUtils::read_file(filename, chars_read, buffer + buf_position, chars_to_read);
+  chars_read += chars_to_read;
   CHECK_RC(rcode);
   return rcode;
+}
+
+size_t FileUtility::read_from_str_buffer(void* buffer, size_t chars_to_read) {
+  size_t readable_chars = std::min<size_t>(str_buffer.size(), chars_to_read);
+  memcpy(buffer, str_buffer.c_str(), readable_chars);
+  str_buffer.erase(0, readable_chars);
+  return readable_chars;
 }
 
 void read_sam_file(std::string filename) {

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -79,7 +79,7 @@ int FileUtility::read_file(void* buffer, size_t chars_to_read) {
     buf_position = read_from_str_buffer(buffer, chars_to_read);
     chars_to_read -= buf_position;
   }
-  int rcode = TileDBUtils::read_file(filename, chars_read, buffer + buf_position, chars_to_read);
+  int rcode = TileDBUtils::read_file(filename, chars_read, (char*)buffer + buf_position, chars_to_read);
   chars_read += chars_to_read;
   CHECK_RC(rcode);
   return rcode;

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -74,8 +74,16 @@ bool FileUtility::generalized_getline(std::string& retval) {
 }
 
 int FileUtility::read_file(void* buffer, size_t chars_to_read) {
-  int rcode = TileDBUtils::read_file(filename, chars_read, buffer, chars_to_read);
-  chars_read += chars_to_read;
+  size_t buf_position = 0;
+  if(str_buffer.size() > 0) {
+    size_t readable_chars = std::min<size_t>(str_buffer.size(), chars_to_read);
+    memcpy(buffer, str_buffer.c_str(), readable_chars);
+    str_buffer.erase(0, readable_chars);
+    chars_to_read = std::min<size_t>(0, chars_to_read - readable_chars);
+    buf_position += readable_chars;
+  }
+  int rcode = TileDBUtils::read_file(filename, chars_read + buf_position, buffer, chars_to_read);
+  chars_read += (chars_to_read + buf_position);
   CHECK_RC(rcode);
   return rcode;
 }

--- a/src/main/cpp/loader/omicsds_schema.h
+++ b/src/main/cpp/loader/omicsds_schema.h
@@ -91,6 +91,9 @@ struct FileUtility {
     CHECK_RC(rcode);
     return rcode;
   }
+
+private:
+  size_t read_from_str_buffer(void* buffer, size_t chars_to_read);
 };
 
 // datastructure that keeps contigs sorted by name and position

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -28,7 +28,8 @@
 include_directories(Catch INTERFACE Catch2/single_include)
 
 set(CPP_TEST_SOURCES
-        test_omicsds_loader.cc)
+        test_omicsds_loader.cc
+        test_file_utility.cc)
 add_executable(ctests ${CPP_TEST_SOURCES})
 target_include_directories(ctests PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/loader)
 target_compile_definitions(ctests PRIVATE -DOMICSDS_TEST_INPUTS="${CMAKE_CURRENT_SOURCE_DIR}/../inputs/")

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -92,14 +92,16 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
       SECTION("test small read") {
         char buf[256];
         size_t read_size = 5;
-        fu.read_file(buf, read_size);
+        int rc = fu.read_file(buf, read_size);
+        REQUIRE(rc == TILEDB_OK);
         REQUIRE(strncmp(buf, test_text.c_str(), read_size) == 0);
         REQUIRE(fu.chars_read == read_size);
         fu.chars_read = 0; // Reset for next test
       }
       SECTION("test full read") {
         char buf[256];
-        fu.read_file(buf, test_text.size());
+        int rc = fu.read_file(buf, test_text.size());
+        REQUIRE(rc == TILEDB_OK);
         REQUIRE(strncmp(buf, test_text.c_str(), test_text.size()) == 0);
         REQUIRE(fu.chars_read == test_text.size());
         fu.chars_read = 0; // Reset for next test
@@ -142,7 +144,8 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
         REQUIRE(retval == "line1");
 
         char buf[10];
-        fu.read_file(buf, strlen("line2\n"));
+        int rc = fu.read_file(buf, strlen("line2\n"));
+        REQUIRE(rc == TILEDB_OK);
         REQUIRE(strncmp(buf, "line2\n", strlen("line2\n")) == 0);
       }
     }

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -1,0 +1,73 @@
+/**
+ * src/test/cpp/test_omicsds_loader.cc
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Test generic SAM reader
+ */
+
+#include <catch2/catch.hpp>
+#include "test_base.h"
+
+#include "omicsds_schema.h"
+#include "tiledb_constants.h"
+
+TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
+  std::string test_text = "line1\nline2\n";
+  SECTION("test writes", "[utility FileUtility write]") {
+    std::string tmp_file = append("write-test");
+    REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
+  }
+  SECTION("test reads", "[utility FileUtility read]") {
+    SECTION("test iterated getline", "[utility FileUtility read getline]") {
+      std::string tmp_file = append("write-test");
+      REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
+      FileUtility fu = FileUtility(tmp_file);
+      
+      std::string retval;
+      fu.generalized_getline(retval);
+      REQUIRE(retval == "line1");
+      REQUIRE(fu.str_buffer == "line2\n");
+      REQUIRE(fu.chars_read == test_text.length());
+      fu.generalized_getline(retval);
+      REQUIRE(retval == "line2");
+      REQUIRE(fu.str_buffer == "");
+      fu.generalized_getline(retval);
+      REQUIRE(retval == "");
+    }
+    SECTION("test file bigger than buffer", "[utility FileUtility read big-file]") {
+      std::string tmp_file = append("big-write-test");
+      std::string large_string = "";
+      FileUtility tmp_fu = FileUtility(tmp_file);
+      for(int i = 0; i < 2*tmp_fu.buffer_size; i++) {
+        large_string = large_string + "a\n";
+      }
+      REQUIRE(FileUtility::write_file(tmp_file, large_string) == TILEDB_OK);
+      FileUtility fu = FileUtility(tmp_file); // Need to recreate the FileUtility class to get new write
+
+      std::string retval;
+      fu.generalized_getline(retval);
+      REQUIRE(retval == "a");
+      REQUIRE(fu.chars_read == fu.str_buffer.size() + (retval.length() + 1));
+      REQUIRE(fu.chars_read == fu.buffer_size);
+    }
+  }
+}

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -74,20 +74,35 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
       REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
       FileUtility fu = FileUtility(tmp_file);
 
-      char buf[256];
+      
       SECTION("test small read") {
+        char buf[256];
         size_t read_size = 5;
         fu.read_file(buf, read_size);
         REQUIRE(strncmp(buf, test_text.c_str(), read_size) == 0);
+        REQUIRE(fu.chars_read == read_size);
+        fu.chars_read = 0; // Reset for next test
       }
       SECTION("test full read") {
+        char buf[256];
         fu.read_file(buf, test_text.size());
         REQUIRE(strncmp(buf, test_text.c_str(), test_text.size()) == 0);
+        REQUIRE(fu.chars_read == test_text.size());
+        fu.chars_read = 0; // Reset for next test
       }
       SECTION("test over-extended read") {
+        char buf[256];
         int rc = fu.read_file(buf, 256);
         REQUIRE(rc == TILEDB_ERR);
         REQUIRE(strncmp(buf, test_text.c_str(), test_text.size()) == 0);
+      }
+      SECTION("test multiple reads") {
+        char buf[256];
+        size_t read_size = 4;
+        int rc = fu.read_file(buf, read_size);
+        REQUIRE(strncmp(buf, test_text.c_str(), read_size) == 0);
+        rc = fu.read_file(buf, read_size);
+        REQUIRE(strncmp(buf, test_text.c_str() + read_size, read_size) == 0);
       }
     }
   }

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -69,5 +69,26 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
       REQUIRE(fu.chars_read == fu.str_buffer.size() + (retval.length() + 1));
       REQUIRE(fu.chars_read == fu.buffer_size);
     }
+    SECTION("test read file", "[utility FileUtility readfile]") {
+      std::string tmp_file = append("big-write-test");
+      REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
+      FileUtility fu = FileUtility(tmp_file);
+
+      char buf[256];
+      SECTION("test small read") {
+        size_t read_size = 5;
+        fu.read_file(buf, read_size);
+        REQUIRE(strncmp(buf, test_text.c_str(), read_size) == 0);
+      }
+      SECTION("test full read") {
+        fu.read_file(buf, test_text.size());
+        REQUIRE(strncmp(buf, test_text.c_str(), test_text.size()) == 0);
+      }
+      SECTION("test over-extended read") {
+        int rc = fu.read_file(buf, 256);
+        REQUIRE(rc == TILEDB_ERR);
+        REQUIRE(strncmp(buf, test_text.c_str(), test_text.size()) == 0);
+      }
+    }
   }
 }

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -129,6 +129,15 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
         REQUIRE(retval == "a");
         REQUIRE(fu.chars_read == fu.str_buffer.size() + (retval.length() + 1));
         REQUIRE(fu.chars_read == fu.buffer_size);
+        
+        SECTION("test read_line after generalized_getline with big write") {
+          char buf[1024];
+          size_t read_size = fu.str_buffer.size() + 10;
+          size_t chars_read = fu.chars_read;
+          REQUIRE(fu.read_file(buf, read_size) == TILEDB_OK);
+          REQUIRE(chars_read + 10 == fu.chars_read);
+          REQUIRE(strncmp(buf, large_string.substr(2, read_size).c_str(), read_size) == 0);
+        }
       }
       SECTION("test file bigger than buffer without newline", "[utility FileUtility read big-file]") {
         std::string large_string = "";


### PR DESCRIPTION
Adds functional tests for the public API of the `FileUtility` class.

When writing these tests I found that calling `read_file` after a `generalized_getline` call would result in `read_file` missing any data that had already been buffered. I updated the logic of the function and included a test for this case, but if that was the expected behavior of the API I can revert these changes.