### PR TITLE
Compiler warning fixes

### DIFF
--- a/src/main/cpp/loader/omicsds_export.cc
+++ b/src/main/cpp/loader/omicsds_export.cc
@@ -142,7 +142,7 @@ static std::string cigar_to_string(const uint32_t* cigar, size_t n_cigar) {
 
   std::stringstream ss;
 
-  for(int i = 0; i < n_cigar; i++) {
+  for(size_t i = 0; i < n_cigar; i++) {
     uint32_t op_idx = cigar[i] & op_mask;
     if(op_idx >= sizeof(cigar_codes)) {
       std::cerr << "Error, cigar is badly formed" << std::endl;

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -29,7 +29,7 @@
 
 std::vector<std::string> split(std::string str, std::string sep) {
   std::vector<std::string> retval;
-  int index;
+  size_t index;
 
   if(str.length() >= 2) {
     if(str[0] == '[') {
@@ -50,7 +50,7 @@ bool FileUtility::generalized_getline(std::string& retval) {
   retval = "";
 
   while(chars_read < file_size || str_buffer.size()) {
-    int idx = str_buffer.find('\n');
+    size_t idx = str_buffer.find('\n');
     if(idx != std::string::npos) {
       retval = retval + str_buffer.substr(0, idx); // exclude newline
       str_buffer.erase(0, idx + 1); // erase newline
@@ -125,7 +125,7 @@ void read_sam_file(std::string filename) {
 
     char *qseq = (char *)malloc(len);
     
-    for(int i=0; i<len; i++){
+    for(size_t i=0; i<len; i++){
       qseq[i] = seq_nt16_str[bam_seqi(q,i)]; //gets nucleotide id and converts them into IUPAC id.
     }
     
@@ -423,7 +423,7 @@ std::vector<OmicsCell> SamReader::get_next_cells() {
     int32_t tlen = m_align->core.isize;
     std::vector<char> qseq(len);
 
-    for(int i=0; i< len ; i++){
+    for(size_t i=0; i< len ; i++){
       qseq[i] = seq_nt16_str[bam_seqi(q,i)]; //gets nucleotide id and converts them into IUPAC id.
     }
 
@@ -589,7 +589,7 @@ bool MatrixReader::parse_next(std::string& sample, std::string& gene, float& sco
     m_current_token = toks[0];
 
     try {
-      for(int i = 0; i < m_columns.size(); i++) {
+      for(size_t i = 0; i < m_columns.size(); i++) {
         m_row_scores[i] = std::stof(toks[i + 1]);
       }
     }

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -238,7 +238,7 @@ uint64_t GenomicMap::flatten(std::string contig_name, uint64_t offset) {
 bool equivalent_schema(const OmicsSchema& l, const OmicsSchema& r) {
   if(l.attributes.size() != r.attributes.size()) return false;
 
-  for(auto li = l.attributes.begin(), ri = r.attributes.begin(); li != l.attributes.end(), ri != r.attributes.end(); li++, ri++) {
+  for(auto li = l.attributes.begin(), ri = r.attributes.begin(); (li != l.attributes.end()) && (ri != r.attributes.end()); li++, ri++) {
     if(li->first != ri->first) return false;
     if(li->second.type != ri->second.type) return false;
   }

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -827,7 +827,7 @@ void OmicsLoader::buffer_cell(const OmicsCell& cell, int level) {
     auto& data = fiter->data;
 
     int length = aiter->second.length;
-    int size = aiter->second.element_size();
+    size_t size = aiter->second.element_size();
     if(length == TILEDB_VAR_NUM) { // variable length
       OmicsFieldData::push_back<size_t>(offset_buffers[i], attribute_offsets[i]);
       attribute_offsets[i] += data.size();
@@ -836,7 +836,8 @@ void OmicsLoader::buffer_cell(const OmicsCell& cell, int level) {
       }
     }
     else {
-      assert(data.size() == size * length);
+      assert(length >= 0); // Should only be negative if variable
+      assert(data.size() == size * (size_t) length);
       for(auto& c : data) {
         offset_buffers[i].push_back(c);
       }

--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -238,7 +238,7 @@ uint64_t GenomicMap::flatten(std::string contig_name, uint64_t offset) {
 bool equivalent_schema(const OmicsSchema& l, const OmicsSchema& r) {
   if(l.attributes.size() != r.attributes.size()) return false;
 
-  for(auto li = l.attributes.begin(), ri = r.attributes.begin(); (li != l.attributes.end()) && (ri != r.attributes.end()); li++, ri++) {
+  for(auto li = l.attributes.begin(), ri = r.attributes.begin(); li != l.attributes.end(), ri != r.attributes.end(); li++, ri++) {
     if(li->first != ri->first) return false;
     if(li->second.type != ri->second.type) return false;
   }

--- a/src/main/cpp/loader/omicsds_loader.h
+++ b/src/main/cpp/loader/omicsds_loader.h
@@ -229,6 +229,7 @@ class OmicsFileReader { // FIXME encode whether cells are end cells (can be dedu
   public:
     OmicsFileReader(std::string filename, std::shared_ptr<OmicsSchema> schema, std::shared_ptr<SampleMap> sample_map, int file_idx) : /*m_file(filename),*/ m_reader_util(std::make_shared<FileUtility>(filename)), m_schema(schema), m_sample_map(sample_map), m_file_idx(file_idx) {
     }
+    virtual ~OmicsFileReader() = default;
 
     const std::string& get_filename() {
       return m_reader_util->filename;

--- a/src/main/cpp/loader/omicsds_schema.h
+++ b/src/main/cpp/loader/omicsds_schema.h
@@ -221,7 +221,7 @@ struct OmicsFieldInfo {
     return std::to_string(length);
   }
 
-  int element_size() {
+  size_t element_size() {
     switch(type) {
       case omics_char:     return 1;
       case omics_uint8_t:  return 1;


### PR DESCRIPTION
Fixes up some of the build errors that are emitted when compiling OmicsDS. Mostly this is updating loop control variables to be `size_t`'s rather than `int`'s. Also adds a virtual destructor to the `OmicsFileReader` class to prevent `Wdelete-non-abstract-non-virtual-dtor` errors in the Apple clang build.

There are two remaining warnings in the clang build that I will open issues for. They impact the logic of the program more heavily than these changes, so I didn't want to address them without unit tests in place.