### PR TITLE
Fix OmicsFieldData::push_pointer_back and the associated unit tests

### DIFF
--- a/src/main/cpp/loader/omicsds_schema.h
+++ b/src/main/cpp/loader/omicsds_schema.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <utility>
 
@@ -304,16 +305,12 @@ struct OmicsFieldData {
     push_back(data, elem);
   }
 
-  // templated utilty function to insert elements of potentially more than one byte into vector via pointer
-  // useful for c strings/vectors
-  template<class T>
-  void push_pointer_back(const T* elem_ptr, int n) {
-    size_t size = data.size();
-    data.resize(data.size() + sizeof(T)*n);
-    T* ptr = reinterpret_cast<T*>(data.data() + size);
-
-    for(int i = 0; i < n; i++) {
-      ptr[i] = elem_ptr[i];
+  // templated utility function to insert elements of integral types and of size length.
+  template<typename T>
+  void push_pointer_back(const T* elem_ptr, size_t length) {
+    static_assert(std::is_integral<T>::value, "Only Integral types can be specified.");
+    for(auto i = 0ul; i < length; i++) {
+      push_back(*(elem_ptr+i));
     }
   }
   

--- a/src/test/cpp/test_omics_field_data.cc
+++ b/src/test/cpp/test_omics_field_data.cc
@@ -44,7 +44,9 @@ TEST_CASE("test OmicsFieldData class", "[omicsfielddata]") {
     ofd.push_back(my_struct);
 
     std::string string_arr[3] = {"string0", "string1", "string2"};
-    ofd.push_pointer_back(string_arr, 3);
+    for (auto i=0u; i<3; i++) {
+      ofd.push_pointer_back(string_arr[i].c_str(), string_arr[i].length());
+    }
 
     SECTION("test array gets", "[omicsfielddata operator-bracket]") {
       size_t byte_offset = 0;
@@ -60,13 +62,13 @@ TEST_CASE("test OmicsFieldData class", "[omicsfielddata]") {
       REQUIRE(ret_struct->z == 15903);
       byte_offset += sizeof(test_struct);
 
-      std::string str_buf[3];
-      memcpy(str_buf, ofd.get_ptr<uint8_t>() + byte_offset, 3*sizeof(std::string));
-      REQUIRE(str_buf[0] == "string0");
-      REQUIRE(str_buf[1] == "string1");
-      REQUIRE(str_buf[2] == "string2");
+      char str_buf[8];
+      for (auto i=0ul; i<3; i++) {
+	memcpy(str_buf, ofd.get_ptr<uint8_t>() + byte_offset, string_arr[i].length());
+	REQUIRE(str_buf == string_arr[i]);
+	byte_offset += string_arr[i].length();
+      }
 
-      byte_offset += sizeof(str_buf);
       REQUIRE(ofd.size() == byte_offset);
     }
 
@@ -97,11 +99,11 @@ TEST_CASE("test OmicsFieldData class", "[omicsfielddata]") {
     }
 
     SECTION("test typed sizes", "[omicsfielddata sizes]") {
-      size_t size = sizeof(int) + sizeof(char) + sizeof(test_struct) + 3*sizeof(std::string);
+      size_t size = sizeof(int) + sizeof(char) + sizeof(test_struct) + string_arr[0].length()
+	+ string_arr[1].length() + string_arr[2].length();
       REQUIRE(ofd.typed_size<int>() == size / sizeof(int));
-      REQUIRE(ofd.typed_size<char>() == size / sizeof(char));
+      REQUIRE(ofd.typed_size<char>() == size /sizeof(char));
       REQUIRE(ofd.typed_size<test_struct>() == size / sizeof(test_struct));
-      REQUIRE(ofd.typed_size<std::string>() == size / sizeof(std::string));
     }
   }
 }


### PR DESCRIPTION
OmicsFieldData::push_pointer_back can only work with integral(basic) types as it exists in code right  now. Changed the code and the associated unit tests to reflect this.