### PR TITLE
Lw getline fix

### DIFF
--- a/src/main/cpp/loader/omicsds_loader.cc
+++ b/src/main/cpp/loader/omicsds_loader.cc
@@ -69,8 +69,8 @@ bool FileUtility::generalized_getline(std::string& retval) {
 
     str_buffer.insert(str_buffer.end(), buffer, buffer + chars_to_read);
   }
-
-  return false;
+  // Last line of the file may be lacking a newline
+  return retval != "";
 }
 
 int FileUtility::read_file(void* buffer, size_t chars_to_read) {

--- a/src/test/cpp/test_file_utility.cc
+++ b/src/test/cpp/test_file_utility.cc
@@ -37,24 +37,37 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
     std::string tmp_file = append("write-test");
     REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
   }
+
   
   SECTION("test reads", "[utility FileUtility read]") {
     std::string tmp_file = append("read-test");
     SECTION("test common reads", "[utility FileUtility read]") {
+      SECTION("test no newline") {
+        REQUIRE(FileUtility::write_file(tmp_file, test_text.substr(0, test_text.size()-1)) == TILEDB_OK);
+        FileUtility fu = FileUtility(tmp_file);
+        
+        std::string retval;
+        
+        REQUIRE(fu.generalized_getline(retval));
+        REQUIRE(retval == "line1");
+        REQUIRE(fu.generalized_getline(retval));
+        REQUIRE(retval == "line2");
+      }
+
       REQUIRE(FileUtility::write_file(tmp_file, test_text) == TILEDB_OK);
 
       SECTION("test iterated getline", "[utility FileUtility read getline]") {
         FileUtility fu = FileUtility(tmp_file);
         
         std::string retval;
-        fu.generalized_getline(retval);
+        REQUIRE(fu.generalized_getline(retval));
         REQUIRE(retval == "line1");
         REQUIRE(fu.str_buffer == "line2\n");
         REQUIRE(fu.chars_read == test_text.length());
-        fu.generalized_getline(retval);
+        REQUIRE(fu.generalized_getline(retval));
         REQUIRE(retval == "line2");
         REQUIRE(fu.str_buffer == "");
-        fu.generalized_getline(retval);
+        REQUIRE(!fu.generalized_getline(retval));
         REQUIRE(retval == "");
       }
       SECTION("test read file", "[utility FileUtility readfile]") {
@@ -97,14 +110,14 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
           REQUIRE(strncmp(buf, "line1\n", strlen("line1\n")) == 0);
 
           std::string retval;
-          fu.generalized_getline(retval);
+          REQUIRE(fu.generalized_getline(retval));
           REQUIRE(retval == "line2");
         }
         SECTION("test getline -> read_file") {
           FileUtility fu = FileUtility(tmp_file);
 
           std::string retval;
-          fu.generalized_getline(retval);
+          REQUIRE(fu.generalized_getline(retval));
           REQUIRE(retval == "line1");
 
           char buf[10];
@@ -125,7 +138,7 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
         FileUtility fu = FileUtility(tmp_file); // Need to recreate the FileUtility class to pick up the write
 
         std::string retval;
-        fu.generalized_getline(retval);
+        REQUIRE(fu.generalized_getline(retval));
         REQUIRE(retval == "a");
         REQUIRE(fu.chars_read == fu.str_buffer.size() + (retval.length() + 1));
         REQUIRE(fu.chars_read == fu.buffer_size);
@@ -150,7 +163,7 @@ TEST_CASE_METHOD(TempDir, "test FileUtility", "[utility FileUtility]") {
         FileUtility fu = FileUtility(tmp_file); // Need to recreate the FileUtility class to get new write
 
         std::string retval;
-        fu.generalized_getline(retval);
+        REQUIRE(fu.generalized_getline(retval));
         REQUIRE(retval == large_string.substr(0, large_string.size() - 1));
       }
     }


### PR DESCRIPTION
See issue: https://github.com/OmicsDataAutomation/OmicsDS/issues/20

Calls to `generalized_getline` would return false on the last line of files without trailing new lines even if there was data successfully read. Any client code that was checking the return value would then miss the returned string. The return value has been updated to reflect this case. A new unit test has been added to catch this error. The remaining test cases have been updated to properly check the return value of `generalized_getline`. This wouldn't have caught this error, but not checking this was an omission in the original tests.