### PR TITLE
macOS Runner Version Bump

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,9 +16,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-11]
+        os: [ubuntu-18.04, macOS-latest]
 
     runs-on: ${{ matrix.os }}
+
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-10.15]
+        os: [ubuntu-18.04, macOS-11]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Bumps the version of the macOS runner from `10.15 -> 11` due to `10.15` being deprecated.