### PR TITLE
Implement logging interface using spdlog

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -33,6 +33,7 @@ set(OMICSDB_INCLUDE
 set(OMICSDS_SOURCES
   ${OMICSDS_CPP}/loader/omicsds_loader.cc
   ${OMICSDS_CPP}/loader/omicsds_export.cc
+  ${OMICSDS_CPP}/utils/omicsds_logger.cc
   )
 
 # Use PIC
@@ -43,7 +44,7 @@ add_library(omicsds_objs OBJECT ${OMICSDS_SOURCES})
 
 target_include_directories(omicsds_objs
   PUBLIC ${CMAKE_BINARY_DIR}/src
-  PRIVATE ${OMICSDS_CPP} ${TILEDB_INCLUDE_DIR}
+  PRIVATE ${OMICSDS_CPP}/utils ${TILEDB_INCLUDE_DIR}
   )
 
 # Create static library

--- a/src/main/cpp/utils/omicsds_logger.cc
+++ b/src/main/cpp/utils/omicsds_logger.cc
@@ -1,0 +1,130 @@
+/**
+ * @file   logger.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ * 
+ * @copyright Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * This file implements the Logger class
+ */
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+#include "omicsds_logger.h"
+
+#define LOGGER_NAME "NativeOmicsDS"
+#define LOGGER_NAME_STRING "OmicsDS.String"
+
+/** Global thread safe logger */
+Logger logger;
+
+std::shared_ptr<spdlog::logger> Logger::get_logger(const std::string& name) {
+  auto new_logger = spdlog::stderr_color_mt(name);
+  // Follow default log4j pattern for now
+  new_logger->set_pattern("%H:%M:%S.%e %-5!l %n - pid=%P tid=%t %v");
+#ifdef NDEBUG
+  new_logger->set_level(spdlog::level::info);
+#else
+  new_logger->set_level(spdlog::level::debug);
+#endif
+  return new_logger;
+}
+
+Logger::Logger() {
+  m_logger = spdlog::get(LOGGER_NAME);
+  if (m_logger == nullptr) {
+    m_logger = get_logger(LOGGER_NAME);
+  }
+
+  setup_string_logger();
+}
+
+Logger::Logger(std::shared_ptr<spdlog::logger> logger) {
+  m_logger = logger;
+  setup_string_logger();
+}
+
+Logger::Logger(std::shared_ptr<spdlog::logger> logger, std::shared_ptr<spdlog::logger> string_logger) {
+  m_logger = logger;
+  m_string_logger = string_logger;
+}
+
+Logger::~Logger() {
+  spdlog::drop_all();
+}
+
+void Logger::info(const std::string& msg, bool once_only) {
+  if (!once_only || not_been_logged(msg)) { 
+    m_string_logger->info(msg.c_str());
+  }
+}
+
+void Logger::debug(const std::string& msg, bool once_only) {
+  if (!once_only || not_been_logged(msg)) { 
+    m_string_logger->debug(msg.c_str());
+  }
+}
+
+void Logger::debug_only(const std::string& msg, bool once_only) {
+#ifdef DEBUG
+  debug(msg, once_only);
+#endif
+}
+
+void Logger::warn(const std::string& msg, bool once_only) {
+  if (!once_only || not_been_logged(msg)) { 
+    m_string_logger->warn(msg.c_str());
+  }
+}
+
+void Logger::error(const std::string& msg, bool once_only) {
+  if (!once_only || not_been_logged(msg)) { 
+    m_string_logger->error(msg.c_str());
+  }
+}
+
+void Logger::setup_string_logger() {
+  m_string_logger = spdlog::get(LOGGER_NAME_STRING);
+  if (m_string_logger == nullptr) {
+    m_string_logger = spdlog::stderr_color_mt(LOGGER_NAME_STRING);
+    // No pattern for string logger
+    m_string_logger->set_pattern("%v");
+#ifdef NDEBUG
+    m_string_logger->set_level(spdlog::level::info);
+#else
+    m_string_logger->set_level(spdlog::level::debug);
+#endif
+  }
+}
+
+bool Logger::not_been_logged(const std::string& msg) {
+  const std::lock_guard<std::mutex> lock(m_once_only_mutex);
+  if (std::find(m_once_only_list.begin(), m_once_only_list.end(), msg) == m_once_only_list.end()) {
+    m_once_only_list.push_back(msg);
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/main/cpp/utils/omicsds_logger.h
+++ b/src/main/cpp/utils/omicsds_logger.h
@@ -1,0 +1,158 @@
+/**
+ * @file   omicsds_logger.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ * 
+ * @copyright Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * This file defines the Logger class
+ */
+
+#pragma once
+
+// Override spdlog level names to upper case for consistency with log4j from Java
+#if !defined(SPDLOG_LEVEL_NAMES)
+#define SPDLOG_LEVEL_NAMES { "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF" }
+#endif
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <exception>
+#include <execinfo.h>
+#include <list>
+#include <mutex>
+#include <sstream>
+
+//TODO: Prototype from TileDB/utils.h for now.
+bool is_env_set(const std::string& name);
+
+class Logger {
+ public:
+  Logger();
+  Logger(std::shared_ptr<spdlog::logger> logger);
+  Logger(std::shared_ptr<spdlog::logger> logger, std::shared_ptr<spdlog::logger> string_logger);
+  ~Logger();
+
+  /** Direct, formatless logging of messages */
+  void info(const std::string& msg, bool once_only=false);
+  void debug(const std::string& msg, bool once_only=false);
+  void debug_only(const std::string& msg, bool once_only=false);
+  void warn(const std::string& msg, bool once_only=false);
+  void error(const std::string& msg, bool once_only=false);
+
+  /* log4j pattern logging of messages */
+  template<typename... Args>
+  void info(const char* fmt, const Args &... args) {
+    m_logger->info(fmt, args...);
+  }
+
+  template<typename... Args>
+  void debug(const char* fmt, const Args &... args) {
+    m_logger->debug(fmt, args...);
+  }
+
+  template<typename... Args>
+  void debug_only(const char* fmt, const Args &... args) {
+#ifdef DEBUG
+    m_logger->debug(fmt, args...);
+#endif
+  }
+
+  template<typename... Args>
+  void warn(const char* fmt, const Args &... args) {
+    m_logger->warn(fmt, args...);
+  }
+
+  template<typename... Args>
+  void error(const char* fmt, const Args &... args) {
+    m_logger->error(fmt, args...);
+  }
+
+#define BACKTRACE_LENGTH 10
+  void print_backtrace() {
+    if (is_env_set("OMICSDS_PRINT_STACKTRACE")) {
+      void *buffer[BACKTRACE_LENGTH];
+      int nptrs = backtrace(buffer, BACKTRACE_LENGTH);
+      char **strings = backtrace_symbols(buffer, nptrs);
+      m_logger->error("Native Stack Trace:");
+      for (auto i = 1; i < nptrs; i++) {
+	m_string_logger->error(std::string("\t")+strings[i]);
+      }
+      free(strings);
+    }
+  }
+
+  template<typename T, typename... Args>
+  void fatal(const T& exception, const char* fmt, const Args &... args) {
+    static_assert(std::is_base_of<std::exception, T>::value, "Template class to fatal() must derive from std::exception");
+    m_logger->error(fmt, args...);
+    print_backtrace();
+    throw exception;
+  }
+
+  template<typename T>
+  void fatal(const T& exception) {
+    static_assert(std::is_base_of<std::exception, T>::value, "Template class to fatal() must derive from std::exception");
+    m_logger->error(exception.what());
+    print_backtrace();
+    throw exception;
+  }
+
+  template<typename... Args>
+  void info_once(const char* fmt, const Args &... args) {
+    if (not_been_logged(format(fmt, args...))) {
+      m_logger->info(fmt, args...);
+    }
+  }
+
+  template<typename... Args>
+  void warn_once(const char* fmt, const Args &... args) {
+    if (not_been_logged(format(fmt, args...))) {
+      m_logger->warn(fmt, args...);
+    }
+  }
+
+  template<typename... Args>
+  const std::string format(const char* fmt, const Args &... args) {
+    return fmt::format(fmt, args...);
+  }
+
+  static std::shared_ptr<spdlog::logger> get_logger(const std::string& name);
+  
+ private:
+  std::shared_ptr<spdlog::logger> m_logger;
+  std::shared_ptr<spdlog::logger> m_string_logger;
+  std::mutex m_once_only_mutex;
+  std::list<std::string> m_once_only_list;
+
+  void setup_string_logger();
+  bool not_been_logged(const std::string& msg);
+};
+
+/** Global thread safe logger */
+extern Logger logger;
+

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -30,9 +30,10 @@ include_directories(Catch INTERFACE Catch2/single_include)
 set(CPP_TEST_SOURCES
         test_omicsds_loader.cc
         test_omics_field_data.cc
-        test_file_utility.cc)
+        test_file_utility.cc
+        test_logger.cc)
 add_executable(ctests ${CPP_TEST_SOURCES})
-target_include_directories(ctests PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/loader)
+target_include_directories(ctests PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/loader ${CMAKE_SOURCE_DIR}/src/main/cpp/utils)
 target_compile_definitions(ctests PRIVATE -DOMICSDS_TEST_INPUTS="${CMAKE_CURRENT_SOURCE_DIR}/../inputs/")
 target_link_libraries(ctests omicsds_static ${OMICSDS_DEPENDENCIES} ${CMAKE_DL_LIBS})
 add_test(ctests ctests -d yes)

--- a/src/test/cpp/test_logger.cc
+++ b/src/test/cpp/test_logger.cc
@@ -1,0 +1,198 @@
+/**
+ * @file src/test/cpp/test_logger.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ * 
+ * @copyright Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * Test the Logger class
+ */
+
+#include <catch2/catch.hpp>
+
+#include "omicsds_logger.h"
+
+#include <iostream>
+#include <stdlib.h>
+#include <string>
+#include <sstream>
+#include <streambuf>
+#include <spdlog/sinks/ostream_sink.h>
+
+#define TEST_STR "This is a test"
+#define TEST_STR_ONCE_ONLY "This is a once_only test"
+
+#define TEST_STR_FMT "i={} str={}"
+
+TEST_CASE("test logger", "[test_logger_basic]") {
+  logger.info(TEST_STR);
+  logger.warn(TEST_STR);
+  logger.error(TEST_STR);
+  logger.debug(TEST_STR);
+
+  const std::string test_str(TEST_STR);
+  logger.info(test_str);
+  logger.warn(test_str);
+  logger.error(test_str);
+  logger.debug(test_str);
+  logger.debug_only(test_str);
+
+  logger.info(std::string(TEST_STR_ONCE_ONLY), true);
+  logger.info(std::string(TEST_STR_ONCE_ONLY), true);
+
+  logger.info(logger.format("Trying format {} {}", "Hello1", "Hello2"));
+}
+
+TEST_CASE("test logger format", "[test_logger_format]") {
+  logger.info(TEST_STR_FMT, 1, TEST_STR);
+  logger.warn(TEST_STR_FMT, 2, TEST_STR);
+  logger.error(TEST_STR_FMT, 3, TEST_STR);
+  logger.debug(TEST_STR_FMT, 4, TEST_STR);
+  logger.debug_only(TEST_STR_FMT, 5, TEST_STR);
+
+  logger.info_once(TEST_STR_FMT, 6, TEST_STR_ONCE_ONLY);
+  logger.info_once(TEST_STR_FMT, 6, TEST_STR_ONCE_ONLY);
+
+  logger.warn_once(TEST_STR_FMT, 7, TEST_STR_ONCE_ONLY);
+  logger.warn_once(TEST_STR_FMT, 7, TEST_STR_ONCE_ONLY);
+
+  CHECK(logger.format(TEST_STR_FMT, 0, TEST_STR).find(TEST_STR) != std::string::npos);
+}
+
+#define TEST_EXCEPTION_STR "Test Exception"
+
+TEST_CASE("test logger exceptions", "[test_logger_exceptions]") {
+  auto exception = std::runtime_error("Test logger exception");
+  CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), std::runtime_error);
+  CHECK_THROWS_AS(logger.fatal(exception),  std::runtime_error);
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "0", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception),  std::runtime_error);
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "1", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception),  std::runtime_error);
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "true", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception),  std::runtime_error);
+  CHECK(unsetenv("OMICDS_PRINT_STACKTRACE") == 0);
+}
+
+#define NATIVE_STACK_TRACE_STR "Native Stack Trace:"
+
+#define CHECK_LOGGER(X, Y)                      \
+  do {                                          \
+      logger.X(Y);                              \
+      CHECK(oss.str() == check_str);            \
+      oss.str("");                              \
+      } while (false)
+
+#define CHECK_STR_LOGGER(X, Y)                  \
+  do {                                          \
+      with_string_logger.X(Y);                  \
+      CHECK(oss.str() == check_str);            \
+      oss.str("");                              \
+      } while (false)                             
+
+TEST_CASE("test explicit logger", "[test_logger_explicit]") {
+  std::ostringstream oss;
+  auto oss_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+  
+  spdlog::logger oss_logger("oss", oss_sink);
+  oss_logger.set_level(spdlog::level::debug);
+  oss_logger.set_pattern("%v");
+  auto oss_shared_logger = std::make_shared<spdlog::logger>(oss_logger);
+
+  const std::string check_str =  std::string(TEST_STR)+spdlog::details::os::default_eol;
+
+  // String logger logs to console  with this constructor
+  Logger logger(oss_shared_logger);
+
+  CHECK_LOGGER(info, TEST_STR);
+  CHECK_LOGGER(warn, TEST_STR);
+#ifdef DEBUG
+  CHECK_LOGGER(debug, TEST_STR);
+  CHECK_LOGGER(debug_only, TEST_STR);
+#endif
+  CHECK_LOGGER(error, TEST_STR);
+
+  logger.info(TEST_STR_FMT, 1, TEST_STR);
+  CHECK(oss.str().find(TEST_STR) != std::string::npos);
+  oss.str("");
+
+  logger.info_once(TEST_STR_FMT, 2, TEST_STR);
+  CHECK(oss.str().find(TEST_STR) != std::string::npos);
+  oss.str("");
+  logger.info_once(TEST_STR_FMT, 2, TEST_STR);
+  CHECK(oss.str() == "");
+
+  // Test Exceptions
+  oss.str("");
+  REQUIRE(unsetenv("OMICSDS_PRINT_STACKTRACE") == 0);
+  auto exception = std::runtime_error("Test Exception");
+  CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), std::runtime_error);
+  CHECK(oss.str().find(TEST_STR) != std::string::npos);
+  CHECK(oss.str().find(NATIVE_STACK_TRACE_STR) == std::string::npos); // Should not dump stack trace
+
+  oss.str("");
+  CHECK_THROWS_AS(logger.fatal(exception), std::runtime_error);
+  CHECK(oss.str().find(TEST_EXCEPTION_STR) != std::string::npos);
+  CHECK(oss.str().find(NATIVE_STACK_TRACE_STR) == std::string::npos); // Should not dump stack trace
+
+  oss.str("");
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "0", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), std::runtime_error);
+  CHECK(oss.str().find(TEST_EXCEPTION_STR) != std::string::npos);
+  CHECK(oss.str().find(NATIVE_STACK_TRACE_STR) == std::string::npos); // Should not dump stack trace
+
+  oss.str("");
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "1", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), std::runtime_error);
+  CHECK(oss.str().find(TEST_EXCEPTION_STR) != std::string::npos);
+  CHECK(oss.str().find(NATIVE_STACK_TRACE_STR) != std::string::npos); // Should dump stack trace
+  CHECK(oss.str().substr(oss.str().find(NATIVE_STACK_TRACE_STR)+1).length() > 0); // Should be the stack trace
+
+  oss.str("");
+  REQUIRE(setenv("OMICSDS_PRINT_STACKTRACE", "true", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), std::runtime_error);
+  CHECK(oss.str().find(TEST_EXCEPTION_STR) != std::string::npos);
+  CHECK(oss.str().find(NATIVE_STACK_TRACE_STR) != std::string::npos); // Should dump stack trace
+  CHECK(oss.str().substr(oss.str().find(NATIVE_STACK_TRACE_STR)+1).length() > 0); // Should be the stack trace
+
+  CHECK(unsetenv("OMICSDS_PRINT_STACKTRACE") == 0);
+  oss.str("");
+
+  // String logger logs to console 
+  const std::string test_str(TEST_STR);
+  logger.info(test_str);
+  CHECK(oss.str() == "");
+
+  Logger with_string_logger(oss_shared_logger, oss_shared_logger);
+  CHECK_STR_LOGGER(info, TEST_STR);
+  CHECK_STR_LOGGER(info, test_str);
+
+  with_string_logger.info(test_str, true);
+  CHECK(oss.str() == check_str);
+  oss.str("");
+  with_string_logger.info(test_str, true);
+  CHECK(oss.str() == "");
+}
+


### PR DESCRIPTION
This is just the same functionality pulled in from GenomicsDB. We probably need to create a utils(OmicsDSUtils GitHub repo??) layer so GenomicsDB and OmicsDS can both benefit, but that is for later.

We can extend the Logger functionality later for tracing and make it configurable with multiple sinks, but this basic functionality should be sufficient for OmicsDS. What I particularly like is the [format functionality](http://fmtlib.net/latest/) similar to how python formatting works.

- Exposed a global Logger instance, sufficient for most uses.
-  Also, `Logger` can be used with `fmt` or directly with `std::string`. When used directly with `std::string` there is no formatting of any kind. The default formatting is similar to the default log4j, but with pid and tid e.g.
`15:58:34.099 info OmicsDS - pid=76840 tid=6826366 This is a test`
`15:58:34.099 warn OmicsDS - pid=76840 tid=6826366 This is a test`
When used directly with std::string, there are no logging prefixes -
`This is a test`
- Extra constructors to instantiate with pre configured Spdlog instances.
- Implemented a `_once` functionality for `info` and `warn` with `fmt`. This should not be used extensively as only a list of strings is constructed to check against if the message was logged previously.

Please start replacing the `std::cerr` and `std::cout` statements in code once this functionality is in.